### PR TITLE
New option to force preserving fractional part of input texture coordinates

### DIFF
--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -9149,11 +9149,12 @@ private:
 				   && (x > comp_x || x == comp_x && ori > comp_ori)));
 		};
 
+		OMP_DISPATCHER
 #if PARALLEL
 		#pragma omp parallel
 #endif // PARALLEL
 		{
-
+			OMP_TRY
 			unsigned int local_best_metric = INT_MAX;
 			int local_best_x = *best_x;
 			int local_best_y = *best_y;
@@ -9182,7 +9183,6 @@ private:
 					|| startPosition.y > endPosition.y)
 					continue;
 
-				OMP_DISPATCHER
 #if PARALLEL
 #pragma omp for collapse(2)
 #endif // PARALLEL
@@ -9232,6 +9232,7 @@ private:
 					XA_DEBUG_ASSERT(local_best_y + chartBitImages.get(0).width() <= (*atlasBitImages)[0]->height());
 				}
 			}
+			OMP_CATCH
 #if PARALLEL
 #pragma omp critical
 #endif // PARALLEL
@@ -9250,6 +9251,7 @@ private:
 				}
 			}
 		}
+		OMP_RETHROW
 
 		if (best_metric == INT_MAX)
 			return false;

--- a/source/xatlas/xatlas.h
+++ b/source/xatlas/xatlas.h
@@ -233,6 +233,13 @@ struct PackOptions
 	// Transpose charts to improve packing.
 	bool transposeCharts = true;
 
+	// In case of photogrammetry texturing each built texture pixel was sampled from pixel in the "best" photo.
+	// To mitigate information loss/blur due to color sampling from the "best" photo - it can be
+	// beneficial to have center-to-center atlas-pixel to photo-pixel projection.
+	// So we want to use atlas parametrization based on texture coordinates of 2D projection into "best" photo.
+	// And to guarantee center-to-center pixel-pixel projection - we need to preserve fractional part of such texture coordinates. 
+	bool preserveInputTexcoordsFractionalPart = false;
+
 	// Number of steps in coarse-to-fine scheme.
 	// Number of N means that N charts and atlases of smaller resolution would be generated.
 	// N=0 means no coarse-to-fine scheme would be applied.


### PR DESCRIPTION
In case of photogrammetry texturing each built texture pixel was sampled from pixel in the "best" photo. To mitigate information loss/blur due to color sampling from the "best" photo - it can be beneficial to have center-to-center atlas-pixel to photo-pixel projection.

So we want to use atlas parametrization based on texture coordinates of 2D projection into "best" photo. And to guarantee center-to-center pixel-pixel projection - we need to preserve fractional part of such texture coordinates. 